### PR TITLE
Fix hardware crash for D3D shader error

### DIFF
--- a/source/Assets/Audio/Music/Secheron Peak - Slow Gravity - licence.txt.meta
+++ b/source/Assets/Audio/Music/Secheron Peak - Slow Gravity - licence.txt.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f266cd09905d38d4d910d2755ea6bd78
+timeCreated: 1443134629
+licenseType: Free
+TextScriptImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/Assets/Prefabs/MainCamera.prefab
+++ b/source/Assets/Prefabs/MainCamera.prefab
@@ -15,7 +15,6 @@ GameObject:
   - 114: {fileID: 11436478}
   - 114: {fileID: 11485934}
   - 114: {fileID: 11433532}
-  - 114: {fileID: 11421636}
   - 114: {fileID: 11410728}
   m_Layer: 0
   m_Name: MainCamera
@@ -107,32 +106,6 @@ MonoBehaviour:
   separableBlurShader: {fileID: 4800000, guid: e97c14fbb5ea04c3a902cc533d7fc5d1, type: 3}
   chromAberrationShader: {fileID: 4800000, guid: 2b4f29398d9484ccfa9fd220449f5eee,
     type: 3}
---- !u!114 &11421636
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 164774}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9191284b058eef549b7108b5f04e1117, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  intensityMultiplier: .300000012
-  generalIntensity: .5
-  blackIntensity: 1
-  whiteIntensity: 1
-  midGrey: .200000003
-  dx11Grain: 0
-  softness: 0
-  monochrome: 0
-  intensities: {x: .0745098069, y: 1, z: 0}
-  tiling: {x: 64, y: 64, z: 64}
-  monochromeTiling: 64
-  filterMode: 1
-  noiseTexture: {fileID: 2800000, guid: 7a632f967e8ad42f5bd275898151ab6a, type: 3}
-  noiseShader: {fileID: 4800000, guid: b0249d8c935344451aa4de6db76f0688, type: 3}
-  dx11NoiseShader: {fileID: 4800000, guid: 8b30686bb4322ab42ad5eb50a0210b58, type: 3}
 --- !u!114 &11433532
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/source/Assets/Prefabs/MainCamera.prefab
+++ b/source/Assets/Prefabs/MainCamera.prefab
@@ -15,6 +15,7 @@ GameObject:
   - 114: {fileID: 11436478}
   - 114: {fileID: 11485934}
   - 114: {fileID: 11433532}
+  - 114: {fileID: 11496802}
   - 114: {fileID: 11410728}
   m_Layer: 0
   m_Name: MainCamera
@@ -156,6 +157,29 @@ MonoBehaviour:
   blurIterations: 1
   blurType: 0
   fastBloomShader: {fileID: 4800000, guid: 68a00c837b82e4c6d92e7da765dc5f1d, type: 3}
+--- !u!114 &11496802
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 164774}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a88a26a276b4e47619ce2c5adad33fab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  monochrome: 0
+  grainIntensityMin: .100000001
+  grainIntensityMax: .300000012
+  grainSize: .5
+  scratchIntensityMin: 0
+  scratchIntensityMax: 0
+  scratchFPS: 1
+  scratchJitter: 0
+  grainTexture: {fileID: 2800000, guid: ffa9c02760c2b4e8eb9814ec06c4b05b, type: 3}
+  scratchTexture: {fileID: 2800000, guid: 6205c27cc031f4e66b8ea90d1bfaa158, type: 3}
+  shaderRGB: {fileID: 4800000, guid: 5d7f4c401ae8946bcb0d6ff68a9e7466, type: 3}
+  shaderYUV: {fileID: 4800000, guid: 0e447868506ba49f0a73235b8a8b647a, type: 3}
 --- !u!124 &12492996
 Behaviour:
   m_ObjectHideFlags: 1
@@ -169,7 +193,35 @@ Prefab:
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
-    m_Modifications: []
+    m_Modifications:
+    - target: {fileID: 0}
+      propertyPath: scratchIntensityMin
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: scratchIntensityMax
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: scratchFPS
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: scratchJitter
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: grainSize
+      value: .5
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: monochrome
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: grainIntensityMax
+      value: .300000012
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 164774}

--- a/source/Assets/Prefabs/Player.prefab
+++ b/source/Assets/Prefabs/Player.prefab
@@ -13,6 +13,7 @@ GameObject:
   - 92: {fileID: 9256508}
   - 114: {fileID: 11488288}
   - 114: {fileID: 11460808}
+  - 114: {fileID: 11487506}
   - 114: {fileID: 11434874}
   - 114: {fileID: 11434382}
   m_Layer: 0
@@ -318,6 +319,29 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   shakeAmount: .0500000007
   shakeDecreaseFactor: 2
+--- !u!114 &11487506
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 103284}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a88a26a276b4e47619ce2c5adad33fab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  monochrome: 0
+  grainIntensityMin: .100000001
+  grainIntensityMax: .300000012
+  grainSize: .5
+  scratchIntensityMin: 0
+  scratchIntensityMax: 0
+  scratchFPS: 1
+  scratchJitter: 0
+  grainTexture: {fileID: 2800000, guid: ffa9c02760c2b4e8eb9814ec06c4b05b, type: 3}
+  scratchTexture: {fileID: 2800000, guid: 6205c27cc031f4e66b8ea90d1bfaa158, type: 3}
+  shaderRGB: {fileID: 4800000, guid: 5d7f4c401ae8946bcb0d6ff68a9e7466, type: 3}
+  shaderYUV: {fileID: 4800000, guid: 0e447868506ba49f0a73235b8a8b647a, type: 3}
 --- !u!114 &11488288
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/source/Assets/Prefabs/Player.prefab
+++ b/source/Assets/Prefabs/Player.prefab
@@ -13,7 +13,6 @@ GameObject:
   - 92: {fileID: 9256508}
   - 114: {fileID: 11488288}
   - 114: {fileID: 11460808}
-  - 114: {fileID: 11479252}
   - 114: {fileID: 11434874}
   - 114: {fileID: 11434382}
   m_Layer: 0
@@ -306,32 +305,6 @@ MonoBehaviour:
   maxBlurSize: 5
   downsample: 0
   tiltShiftShader: {fileID: 4800000, guid: bf34d2a25450349699e8ae6456fa7ca9, type: 3}
---- !u!114 &11479252
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 103284}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9191284b058eef549b7108b5f04e1117, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  intensityMultiplier: .300000012
-  generalIntensity: .5
-  blackIntensity: 1
-  whiteIntensity: 1
-  midGrey: .200000003
-  dx11Grain: 0
-  softness: 0
-  monochrome: 0
-  intensities: {x: .0745098069, y: 1, z: 0}
-  tiling: {x: 64, y: 64, z: 64}
-  monochromeTiling: 64
-  filterMode: 1
-  noiseTexture: {fileID: 2800000, guid: 7a632f967e8ad42f5bd275898151ab6a, type: 3}
-  noiseShader: {fileID: 4800000, guid: b0249d8c935344451aa4de6db76f0688, type: 3}
-  dx11NoiseShader: {fileID: 4800000, guid: 8b30686bb4322ab42ad5eb50a0210b58, type: 3}
 --- !u!114 &11483794
 MonoBehaviour:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
This PR solves the `D3D shader create error for shader [0x80070057] vs_5_0` error. Seems that Noise and Gain image effect from Standard Assets was causing the issue. I replaced it by Noise and Scratches.
